### PR TITLE
Add options to overwrite & merge files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /vendor/
 composer.lock
-
+.phpunit.result.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 2.0.0
+### Removed
+- Support for PHP < 8.1
+
 ## 1.2.2
 ### Fixed
 - Parent directory at destination is now created if it did not exist already.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## 2.0.0
+### Added
+- Option to merge file contents line by line, this is useful for .gitignore files
+- Option to force overwrite files during installation
+
 ### Removed
 - Support for PHP < 8.1
 

--- a/README.md
+++ b/README.md
@@ -4,16 +4,36 @@ Uses the [youwe/file-mapping](https://github.com/YouweGit/file-mapping) package 
 a source -> destination mapping. The Composer `IOInterface` supplies the file installer with the capability to 
 write the files and supply end-users with output messages.
 
-## Usage example
+## Usage
+
+Create a mapping config file according to the [youwe/file-mapping](https://github.com/YouweGit/file-mapping) documentation.
+```text
+file1.php
+file2.php:force-overwrite
+{dot,.}gitignore:merge-line-by-line
+```
+
+### Available options
+
+| Option               | Explanation                                                                                                                                                                                                                                                                                     |
+|----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `merge-line-by-line` | Performs a line-by-line merge. Every line from the source that doesn't exist in the destination yet will be copied over. Comments will be ignored (will not be copied again). The destination file will be created if it doesn't exist yet. This is particularly useful for `.gitignore` files. |
+| `force-overwrite`    | Forces an overwrite, even if the file already exists on the destination.                                                                                                                                                                                                                        |
+| (no option given)    | The file will be copied over if it didn't exist yet and will be left untouched otherwise.                                                                                                                                                                                                       |
+
+### Code example
 ```php
 <?php
+
+use Youwe\FileMapping\UnixFileMappingReader;
+use Youwe\Composer\FileInstaller;
+
 // Create a file mapping.
 $mappingFilePaths = new UnixFileMapping(
      __DIR__ . '/../folder/files',
      getcwd(),
-     ['./dir/one','./dir/two']
-
- );
+     './path/to/mapping-config'
+);
 
 // Get a file mapping reader.
 $reader = new UnixFileMappingReader($sourceDirectory, $targetDirectory, $mappingFilePaths);

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,13 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^8.1",
         "youwe/file-mapping": "~1.1.0"
     },
     "require-dev": {
-        "composer/composer": "@stable",
-        "kint-php/kint": "@stable",
-        "mikey179/vfsstream": "@stable",
-        "phpunit/phpunit": "@stable"
+        "composer/composer": "^2.0",
+        "mikey179/vfsstream": "^1.6",
+        "phpunit/phpunit": "^12.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "youwe/file-mapping": "~1.1.0"
+        "youwe/file-mapping": "^2.0"
     },
     "require-dev": {
         "composer/composer": "^2.0",

--- a/src/FileInstaller.php
+++ b/src/FileInstaller.php
@@ -17,6 +17,9 @@ use Youwe\FileMapping\FileMappingReaderInterface;
 
 class FileInstaller
 {
+    public const MAPPING_OPTION_MERGE_LINE_BY_LINE = 'merge-line-by-line';
+    public const MAPPING_OPTION_FORCE_OVERWRITE = 'force-overwrite';
+
     /**
      * Constructor.
      *
@@ -38,15 +41,25 @@ class FileInstaller
     public function install(IOInterface $io): void
     {
         foreach ($this->mappingReader as $mapping) {
-            if (file_exists($mapping->getDestination())) {
-                continue;
+            if (in_array(self::MAPPING_OPTION_MERGE_LINE_BY_LINE, $mapping->getOptions(), true)) {
+                $this->mergeLineByLine($mapping);
+                $done = 'Merged with existing';
+            } elseif (file_exists($mapping->getDestination())) {
+                if (in_array(self::MAPPING_OPTION_FORCE_OVERWRITE, $mapping->getOptions(), true)) {
+                    $this->installFile($mapping);
+                    $done = 'Overwritten existing';
+                } else {
+                    $done = 'Skipped existing';
+                }
+            } else {
+                $this->installFile($mapping);
+                $done = 'Installed';
             }
-
-            $this->installFile($mapping);
 
             $io->write(
                 sprintf(
-                    '<info>Installed:</info> %s',
+                    '<info>%s:</info> %s',
+                    $done,
                     $mapping->getRelativeDestination(),
                 )
             );
@@ -64,18 +77,65 @@ class FileInstaller
      */
     public function installFile(FileMappingInterface $mapping): void
     {
-        $destination = $mapping->getDestination();
-        $parent = dirname($destination);
-
-        if (!is_dir($parent) && !mkdir($parent, 0755, true) && !is_dir($parent)) {
-            throw new RuntimeException("Directory \"$parent\" could not be created");
-        }
+        $this->ensureDirectoryExists($mapping);
 
         $inputFile  = new SplFileObject($mapping->getSource(), 'r');
-        $targetFile = new SplFileObject($destination, 'w+');
+        $targetFile = new SplFileObject($mapping->getDestination(), 'w');
 
         foreach ($inputFile as $input) {
             $targetFile->fwrite($input);
         }
+    }
+
+    public function mergeLineByLine(FileMappingInterface $mapping): void
+    {
+        if (!file_exists($mapping->getDestination())) {
+            $this->installFile($mapping);
+            return;
+        }
+
+        $inputFile = new SplFileObject($mapping->getSource(), 'r');
+        if (!$inputFile->isFile()) {
+            throw new RuntimeException("Merge line-by-line is only available on regular files, '" . $inputFile->getRealPath() . "' is a ". $inputFile->getType());
+        }
+
+        $targetFile = new SplFileObject($mapping->getDestination(), 'a+');
+        $existingLines = array_map(self::stripCommentFromLine(...), iterator_to_array($targetFile));
+
+        $targetFile->fseek($targetFile->getSize() - 1);
+        $fileEndsWithNewLine = $targetFile->fgetc() === "\n";
+        // Note: cursor in targetFile is now at end
+
+        foreach ($inputFile as $line) {
+            if (empty(trim($line)) || in_array(self::stripCommentFromLine($line), $existingLines)) {
+                continue;
+            }
+
+            if (!$fileEndsWithNewLine) {
+                $targetFile->fwrite("\n");
+                $fileEndsWithNewLine = true;
+            }
+            $targetFile->fwrite(rtrim($line, "\r\n") . "\n");
+        }
+    }
+
+    private function ensureDirectoryExists(FileMappingInterface $mapping): void
+    {
+        $parent = dirname($mapping->getDestination());
+
+        if (!is_dir($parent) && !mkdir($parent, 0755, true) && !is_dir($parent)) {
+            throw new RuntimeException("Directory \"$parent\" could not be created");
+        }
+    }
+
+    /**
+     * @internal
+     */
+    public static function stripCommentFromLine(string $line): string
+    {
+        // Regex format: ^open_comment|close_comment$
+        // Where open_comment = '//' or '#' or '/**' or '/*' or '*' followed by whitespace
+        // Where close_comment = whitespace followed by '*/'
+        return preg_replace('/^(\/\/|#|\/\*\*|\/\*|\*)\s*|\s*(\*\/)$/', '', trim($line));
     }
 }

--- a/src/FileInstaller.php
+++ b/src/FileInstaller.php
@@ -17,18 +17,14 @@ use Youwe\FileMapping\FileMappingReaderInterface;
 
 class FileInstaller
 {
-    /** @var FileMappingReaderInterface */
-    private $mappingReader;
-
     /**
      * Constructor.
      *
      * @param FileMappingReaderInterface $mappingReader
      */
-    public function __construct(FileMappingReaderInterface $mappingReader)
-    {
-        $this->mappingReader = $mappingReader;
-    }
+    public function __construct(
+        private readonly FileMappingReaderInterface $mappingReader,
+    ) {}
 
     /**
      * Install the deployer files.
@@ -39,7 +35,7 @@ class FileInstaller
      *
      * @SuppressWarnings(PHPMD.ShortVariable)
      */
-    public function install(IOInterface $io)
+    public function install(IOInterface $io): void
     {
         foreach ($this->mappingReader as $mapping) {
             if (file_exists($mapping->getDestination())) {
@@ -51,7 +47,7 @@ class FileInstaller
             $io->write(
                 sprintf(
                     '<info>Installed:</info> %s',
-                    $mapping->getRelativeDestination()
+                    $mapping->getRelativeDestination(),
                 )
             );
         }
@@ -66,7 +62,7 @@ class FileInstaller
      *
      * @SuppressWarnings(PHPMD.ShortVariable)
      */
-    public function installFile(FileMappingInterface $mapping)
+    public function installFile(FileMappingInterface $mapping): void
     {
         $destination = $mapping->getDestination();
         $parent = dirname($destination);

--- a/tests/FileInstallerTest.php
+++ b/tests/FileInstallerTest.php
@@ -11,40 +11,29 @@ namespace Youwe\Composer\Tests;
 
 use Composer\IO\IOInterface;
 use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use Youwe\Composer\FileInstaller;
 use Youwe\FileMapping\FileMappingInterface;
 use Youwe\FileMapping\FileMappingReaderInterface;
 
-/**
- * @coversDefaultClass \Youwe\Composer\FileInstaller
- */
+#[CoversClass(FileInstaller::class)]
 class FileInstallerTest extends TestCase
 {
-    /**
-     * @return void
-     *
-     * @covers ::__construct
-     */
-    public function testConstructor()
+    public function testConstructor(): void
     {
-        /** @noinspection PhpParamsInspection */
+        /** @var FileMappingReaderInterface&MockObject $reader */
+        $reader = $this->createMock(FileMappingReaderInterface::class);
         $this->assertInstanceOf(
             FileInstaller::class,
-            new FileInstaller(
-                $this->createMock(FileMappingReaderInterface::class)
-            )
+            new FileInstaller($reader)
         );
     }
 
-    /**
-     * @return void
-     * @covers ::installFile
-     */
-    public function testInstallFile()
+    public function testInstallFile(): void
     {
-        /** @var FileMappingReaderInterface $reader */
+        /** @var FileMappingReaderInterface&MockObject $reader */
         $reader    = $this->createMock(FileMappingReaderInterface::class);
         $installer = new FileInstaller($reader);
 
@@ -53,13 +42,13 @@ class FileInstallerTest extends TestCase
             null,
             [
                 'source' => [
-                    'foo.php' => 'Foo'
+                    'foo.php' => 'Foo',
                 ],
-                'destination' => []
+                'destination' => [],
             ]
         );
 
-        /** @var FileMappingInterface|PHPUnit_Framework_MockObject_MockObject $mapping */
+        /** @var FileMappingInterface&MockObject $mapping */
         $mapping = $this->createMock(FileMappingInterface::class);
         $mapping
             ->expects($this->once())
@@ -83,13 +72,9 @@ class FileInstallerTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     * @covers ::installFile
-     */
-    public function testInstallFileWhenDestinationPathNotExistsYet()
+    public function testInstallFileWhenDestinationPathNotExistsYet(): void
     {
-        /** @var FileMappingReaderInterface $reader */
+        /** @var FileMappingReaderInterface&MockObject $reader */
         $reader = $this->createMock(FileMappingReaderInterface::class);
         $installer = new FileInstaller($reader);
 
@@ -98,13 +83,13 @@ class FileInstallerTest extends TestCase
             null,
             [
                 'source' => [
-                    'foo.php' => 'Foo'
+                    'foo.php' => 'Foo',
                 ],
-                'destination' => []
+                'destination' => [],
             ]
         );
 
-        /** @var FileMappingInterface|PHPUnit_Framework_MockObject_MockObject $mapping */
+        /** @var FileMappingInterface&MockObject $mapping */
         $mapping = $this->createMock(FileMappingInterface::class);
         $mapping
             ->expects($this->once())
@@ -128,13 +113,9 @@ class FileInstallerTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     * @covers ::install
-     */
-    public function testInstall()
+    public function testInstall(): void
     {
-        /** @var FileMappingReaderInterface|PHPUnit_Framework_MockObject_MockObject $reader */
+        /** @var FileMappingReaderInterface&MockObject $reader */
         $reader    = $this->createMock(FileMappingReaderInterface::class);
         $installer = new FileInstaller($reader);
 
@@ -149,7 +130,7 @@ class FileInstallerTest extends TestCase
             ]
         );
 
-        /** @var FileMappingInterface|PHPUnit_Framework_MockObject_MockObject $mapping */
+        /** @var FileMappingInterface&MockObject $mapping */
         $mapping = $this->createMock(FileMappingInterface::class);
         $mapping
             ->expects($this->once())
@@ -185,7 +166,7 @@ class FileInstallerTest extends TestCase
         $io
             ->expects($this->once())
             ->method('write')
-            ->with($this->isType('string'));
+            ->with($this->isString());
 
         $installer->install($io);
 

--- a/tests/FileInstallerTest.php
+++ b/tests/FileInstallerTest.php
@@ -12,8 +12,9 @@ namespace Youwe\Composer\Tests;
 use Composer\IO\IOInterface;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 use Youwe\Composer\FileInstaller;
 use Youwe\FileMapping\FileMappingInterface;
 use Youwe\FileMapping\FileMappingReaderInterface;
@@ -42,7 +43,7 @@ class FileInstallerTest extends TestCase
             null,
             [
                 'source' => [
-                    'foo.php' => 'Foo',
+                    'foo.php' => "Lorum ipsum\nDolor sit amet",
                 ],
                 'destination' => [],
             ]
@@ -51,14 +52,14 @@ class FileInstallerTest extends TestCase
         /** @var FileMappingInterface&MockObject $mapping */
         $mapping = $this->createMock(FileMappingInterface::class);
         $mapping
-            ->expects($this->once())
+            ->expects($this->atLeastOnce())
             ->method('getSource')
             ->willReturn(
                 $fs->getChild('source/foo.php')->url()
             );
 
         $mapping
-            ->expects($this->once())
+            ->expects($this->atLeastOnce())
             ->method('getDestination')
             ->willReturn(
                 $fs->getChild('destination')->url() . '/foo.php'
@@ -68,7 +69,7 @@ class FileInstallerTest extends TestCase
 
         $this->assertStringEqualsFile(
             $fs->getChild('destination/foo.php')->url(),
-            'Foo'
+            "Lorum ipsum\nDolor sit amet"
         );
     }
 
@@ -83,7 +84,7 @@ class FileInstallerTest extends TestCase
             null,
             [
                 'source' => [
-                    'foo.php' => 'Foo',
+                    'foo.php' => "Lorum ipsum\nDolor sit amet",
                 ],
                 'destination' => [],
             ]
@@ -92,14 +93,14 @@ class FileInstallerTest extends TestCase
         /** @var FileMappingInterface&MockObject $mapping */
         $mapping = $this->createMock(FileMappingInterface::class);
         $mapping
-            ->expects($this->once())
+            ->expects($this->atLeastOnce())
             ->method('getSource')
             ->willReturn(
                 $fs->getChild('source/foo.php')->url()
             );
 
         $mapping
-            ->expects($this->once())
+            ->expects($this->atLeastOnce())
             ->method('getDestination')
             ->willReturn(
                 $fs->getChild('destination')->url() . '/path/to/foo.php'
@@ -109,7 +110,56 @@ class FileInstallerTest extends TestCase
 
         $this->assertStringEqualsFile(
             $fs->getChild('destination/path/to/foo.php')->url(),
-            'Foo'
+            "Lorum ipsum\nDolor sit amet"
+        );
+    }
+
+    public function testMergeLineByLine(): void
+    {
+        /** @var FileMappingReaderInterface&MockObject $reader */
+        $reader    = $this->createMock(FileMappingReaderInterface::class);
+        $installer = new FileInstaller($reader);
+
+        $fs = vfsStream::setup(
+            sha1(__METHOD__),
+            null,
+            [
+                'source' => [
+                    'dotgitignore' => "vendor\ncomposer.lock\n\n.env.local\n.env.*.local\nother.txt\n# suggestion.txt\n# suggestion2.txt\n",
+                ],
+                'destination' => [
+                    '.gitignore' => "composer.lock\nvendor\n\napp.config.local.php\nsuggestion.txt\n# other.txt",
+                ],
+            ]
+        );
+
+        /** @var FileMappingInterface&MockObject $mapping */
+        $mapping = $this->createMock(FileMappingInterface::class);
+        $mapping
+            ->expects($this->atLeastOnce())
+            ->method('getSource')
+            ->willReturn(
+                $fs->getChild('source/dotgitignore')->url()
+            );
+
+        $mapping
+            ->expects($this->atLeastOnce())
+            ->method('getDestination')
+            ->willReturn(
+                $fs->getChild('destination/.gitignore')->url()
+            );
+
+        $installer->mergeLineByLine($mapping);
+
+        // - It will leave the composer.lock and vendor as is, these exist in both template and destination (albeit in different order)
+        // - It will leave the app.config.local.php as is, that exist only in destination
+        // - It will leave the (uncommented) suggestion.txt, that exist commented in template and was uncommented in destination already
+        // - It will leave the (commented) other.txt, that exist in template but was commented in destination
+        // - It will add .env.local and .env.*.local, that exist in template but wasn't in the destination yet
+        // - It will add the # suggestion2.txt, that exist in template but wasn't in the destination yet
+        $this->assertSame(
+            "composer.lock\nvendor\n\napp.config.local.php\nsuggestion.txt\n# other.txt\n.env.local\n.env.*.local\n# suggestion2.txt\n",
+            file_get_contents($fs->getChild('destination/.gitignore')->url())
         );
     }
 
@@ -124,57 +174,95 @@ class FileInstallerTest extends TestCase
             null,
             [
                 'source' => [
-                    'foo.php' => 'Foo'
+                    'foo.php' => 'Foo',
+                    'bar.php' => 'Bar',
+                    'other.php' => 'Other',
+                    'dotgitignore' => '.env.local',
                 ],
-                'destination' => []
+                'destination' => [
+                    'bar.php' => 'Custom',
+                    'other.php' => 'Overwrite me',
+                    '.gitignore' => 'vendor',
+                ]
             ]
         );
 
-        /** @var FileMappingInterface&MockObject $mapping */
-        $mapping = $this->createMock(FileMappingInterface::class);
-        $mapping
-            ->expects($this->once())
-            ->method('getSource')
-            ->willReturn(
-                $fs->getChild('source/foo.php')->url()
-            );
+        $createMapping = function (array $options, string $source, string $destination) use ($fs): FileMappingInterface {
+            $mapping = $this->createMock(FileMappingInterface::class);
+            $mapping
+                ->expects($this->atLeastOnce())
+                ->method('getOptions')
+                ->willReturn($options);
+            $mapping
+                ->expects($this->any())
+                ->method('getSource')
+                ->willReturn($fs->getChild('source')->url() . '/' . $source);
+            $mapping
+                ->expects($this->atLeastOnce())
+                ->method('getDestination')
+                ->willReturn($fs->getChild('destination')->url() . '/' . $destination);
+            return $mapping;
+        };
 
-        $mapping
-            ->expects($this->exactly(3))
-            ->method('getDestination')
-            ->willReturn(
-                $fs->getChild('destination')->url() . '/foo.php'
-            );
+        $mapping1 = $createMapping([], 'foo.php', 'foo.php');
+        $mapping2 = $createMapping([], 'bar.php', 'bar.php');
+        $mapping3 = $createMapping([FileInstaller::MAPPING_OPTION_FORCE_OVERWRITE], 'other.php', 'other.php');
+        $mapping4 = $createMapping([FileInstaller::MAPPING_OPTION_MERGE_LINE_BY_LINE], 'dotgitignore', '.gitignore');
 
-        $mapping
-            ->expects($this->once())
-            ->method('getRelativeDestination')
-            ->willReturn('foo.php');
+        $reader
+            ->expects($this->exactly(5))
+            ->method('valid')
+            ->willReturnOnConsecutiveCalls(true, true, true, true, false);
 
         $reader
             ->expects($this->exactly(4))
-            ->method('valid')
-            ->willReturnOnConsecutiveCalls(true, false, true, false);
-
-        $reader
-            ->expects($this->exactly(2))
             ->method('current')
-            ->willReturn($mapping);
+            ->willReturnOnConsecutiveCalls($mapping1, $mapping2, $mapping3, $mapping4);
 
-        /** @var IOInterface|PHPUnit_Framework_MockObject_MockObject $io */
+        /** @var IOInterface&MockObject $io */
         $io = $this->createMock(IOInterface::class);
         $io
-            ->expects($this->once())
+            ->expects($this->exactly(4))
             ->method('write')
             ->with($this->isString());
 
         $installer->install($io);
 
-        $this->assertStringEqualsFile(
-            $fs->getChild('destination/foo.php')->url(),
-            'Foo'
+        $this->assertSame(
+            'Foo',
+            file_get_contents($fs->getChild('destination/foo.php')->url()),
+            'foo.php should be created'
         );
+        $this->assertSame(
+            'Custom',
+            file_get_contents($fs->getChild('destination/bar.php')->url()),
+            'Existing bar.php should not be overwritten'
+        );
+        $this->assertSame(
+            'Other',
+            file_get_contents($fs->getChild('destination/other.php')->url()),
+            'Existing other.php should be replaced'
+        );
+        $this->assertSame(
+            "vendor\n.env.local\n",
+            file_get_contents($fs->getChild('destination/.gitignore')->url()),
+            'Existing .gitignore should be merged'
+        );
+    }
 
-        $installer->install($io);
+    #[TestWith(['hello world', 'hello world'], 'Plain text')]
+    #[TestWith(['  some line  ', 'some line'], 'Normal line is trimmed')]
+    #[TestWith([' # this is commented  ', 'this is commented'], 'Left # is stripped')]
+    #[TestWith(['# this is commented #', 'this is commented #'], 'Right # is not stripped')]
+    #[TestWith([' // php comment  ', 'php comment'], 'Left // is stripped')]
+    #[TestWith([' /** php docblock */ ', 'php docblock'], '/** and */ are stripped')]
+    #[TestWith([' /* php comment 2 */ ', 'php comment 2'], '/* and */ are stripped')]
+    #[TestWith(['ended comment */ ', 'ended comment'], 'ending */ is stripped')]
+    #[TestWith([' * continued comment block ', 'continued comment block'], 'Left * is stripped')]
+    #[TestWith([' * continued ending block */ ', 'continued ending block'], 'Left * and ending */ is stripped')]
+    #[TestWith([' $ other weird characters % are not stripped @ ', '$ other weird characters % are not stripped @'], 'Other chars are not stripped')]
+    public function testStripCommentFromLine(string $line, string $expected): void
+    {
+        $this->assertSame($expected, FileInstaller::stripCommentFromLine($line));
     }
 }


### PR DESCRIPTION
My idea about this PR is that it would be convenient with installing `youwe/testing-suite` in an existing project, that the `.gitignore` additions from the Testing Suite (e.g. the `.phpunit.result.cache` exclusion) are merged with your already existing project `.gitignore`. 

Current setup is: if the file already exists, then don't touch it
Ideal setup for `.gitignore` is: if the file already exists, then merge it